### PR TITLE
Audit back-office DB query plans and add query-shape logging

### DIFF
--- a/docs/bmad/reports/back-office-performance-audit.md
+++ b/docs/bmad/reports/back-office-performance-audit.md
@@ -1,260 +1,402 @@
 # Back Office Performance Audit
 
-**Sprint:** 04-008F  
-**Branch:** `fix/mobile-suara-profile-admin-access-polish`  
-**Date:** 2026-05-04  
-**Status:** PHASE 1–4 COMPLETED — Measurement data pending local run
+**Sprint:** 04-008F
+**Branch:** `fix/mobile-suara-profile-admin-access-polish`
+**Date:** 2026-05-05
+**Status:** DB QUERY PLAN AUDIT IN PROGRESS — root cause narrowed to back-office DB queries; migration pending owner approval
 
 ---
 
 ## 1. Executive Summary
 
-The back office pages (`/profil/admin-desa/*` and `/internal-admin/*`) show sequential
-query chains that cause perceived slowness (5–10 seconds on poor networks). The primary
-bottleneck is the **auth() → context query waterfall** that runs on every layout render,
-combined with repeated `findFirst` / `findMany` calls that are not deduplicated within a
-single request.
+Latest local evidence shows `auth()` is **not** the bottleneck for `/profil/admin-desa/dokumen`.
+The slow path is now isolated to two back-office database queries:
 
-This audit implements Phase 1–4 of the sprint task: instrumentation, loading boundaries,
-request-level dedupe, and low-risk overfetch trimming.
+| Route / Step | Latest local duration | Interpretation |
+|---|---:|---|
+| `/profil/admin-desa/dokumen` → `auth()` | 36ms | Healthy; not the primary bottleneck |
+| `admin-desa.context` → `desaAdminMember.findFirst` | 1648ms | Primary bottleneck candidate |
+| `admin-desa.dokumen` → `adminDesaDocument.findMany` | 1298ms | Primary bottleneck candidate |
+| `/desa` public page load | ~320ms | Public query path is materially faster |
+
+Current conclusion: Phase 1 instrumentation was useful, but the root cause is **not auth latency**.
+The remaining evidence points to back-office query plans: missing or non-covering compound indexes,
+expensive ordering, and relation joins on queries that run before the main page can render.
+
+No UI refactor, business-logic change, or migration is included in this audit update.
 
 ---
 
-## 2. Instrumentation Added
+## 2. Instrumentation Status
 
 **File:** `src/lib/perf.ts`
 
 Helper functions (dev-only, opt-in via `PERF_DEBUG_BACK_OFFICE=true`):
 - `perfEnabled()` — `true` when `NODE_ENV !== "production"` or env var is set
-- `perfStart()` / `perfLog(route, step, timestamp)` — single-line grep-friendly output
+- `perfStart()` / `perfLog(route, step, timestamp)` — duration logging
 - `perfTime(route, step, fn)` — async wrapper
+- `perfQueryShape(route, query, shape)` — query-shape logging without values
 
-**Format:** `[perf][back-office] route=<route> step=<step> durationMs=<number>`
+**Duration format:**
 
-**Privacy:** No PII (userId, email, token, document content) in route/step strings.
-
-### Routes instrumented
-
-| Route | Steps logged |
-|---|---|
-| `admin-desa.layout` | `auth()` |
-| `admin-desa.profil` | `auth()` |
-| `admin-desa.list-admin` | `auth()`, `desaAdminMember+invite.findMany(parallel)` |
-| `admin-desa.dokumen` | `auth()`, `adminDesaDocument.findMany` |
-| `admin-desa.suara` | `auth()`, `voice.findMany` |
-| `admin-desa.notifikasi` | `auth()`, `adminDesaNotification.findMany` |
-| `admin-desa.context` | `desaAdminMember.findFirst` |
-| `internal-admin.layout` | `getInternalAdminSession()` |
-| `internal-admin.claims` | `getInternalAdminSession()`, `desaAdminClaim.findMany+count` |
-| `internal-admin.documents` | `getInternalAdminSession()`, `adminDesaDocument.findMany` |
-| `internal-admin.renewals` | `getInternalAdminSession()`, `desaAdminMember.findMany` |
-| `internal-admin.auth` | `auth()`, `user.findUnique(role)` |
-
-### Expected output (dev console)
-
+```text
+[perf][back-office] route=<route> step=<step> durationMs=<number>
 ```
-[perf][back-office] route=admin-desa.layout step=auth() durationMs=47
-[perf][back-office] route=admin-desa.context step=desaAdminMember.findFirst durationMs=12
-[perf][back-office] route=admin-desa.dokumen step=adminDesaDocument.findMany durationMs=38
-[perf][back-office] route=internal-admin.auth step=auth() durationMs=52
-[perf][back-office] route=internal-admin.auth step=user.findUnique(role) durationMs=8
-[perf][back-office] route=internal-admin.claims step=desaAdminClaim.findMany+count durationMs=91
+
+**Query-shape format:**
+
+```text
+[perf][back-office] route=<route> query=<model.method> shape=<static-shape>
 ```
+
+**Privacy:** Do not log `userId`, `desaId`, `email`, token, session data, storage keys, document content,
+or raw query parameters. Query-shape strings are static descriptors only.
 
 ---
 
-## 3. Root Cause Analysis (Code Review)
+## 3. Latest Local Measurement Evidence
 
-### Finding 1 — Auth + context waterfall (HIGH)
+### 3.1 `/profil/admin-desa/dokumen`
 
-**Affected routes:** ALL `/profil/admin-desa/*` and `/internal-admin/*`
+Observed latest local timings:
 
-Every layout and page independently calls `auth()` (NextAuth session lookup) and then a
-context query. On a cold DB connection or slow network this creates a sequential chain:
-
-```
-auth()          → ~30–80ms (network + JWT verify)
-  └─ getAdminDesaContext() → ~10–50ms (single findFirst + join)
-      └─ (for tabs with extra queries)
-          ├─ getDesaAdminRoster()   → parallel findMany+findMany
-          ├─ voice.findMany(take:50) → full scan + join
-          ├─ adminDesaDocument.findMany(take:100) → full scan
-          └─ adminDesaNotification.findMany(take:50) → full scan
+```text
+route=/profil/admin-desa/dokumen step=auth() durationMs=36
+route=admin-desa.context step=desaAdminMember.findFirst durationMs=1648
+route=admin-desa.dokumen step=adminDesaDocument.findMany durationMs=1298
 ```
 
-**Root cause:** No dedupe between layout and nested page for the same user context.
+Interpretation:
 
-### Finding 2 — Internal admin double auth lookup (MEDIUM)
+1. `auth()` at 36ms is well below the target budget and does not explain multi-second render time.
+2. `desaAdminMember.findFirst` at 1648ms blocks all admin-desa pages because it resolves membership context.
+3. `adminDesaDocument.findMany` at 1298ms is page-specific additional latency for the documents tab.
+4. Combined DB time for the two critical queries is ~2946ms before considering React render, network,
+   hydration, or browser work.
 
-**Affected routes:** ALL `/internal-admin/*`
+### 3.2 `/desa` public comparison
 
-`getInternalAdminSession()` calls both `auth()` and then `isInternalAdmin(userId)`.
-The `isInternalAdmin` does `db.user.findUnique({ select: { role: true } })` — a second
-DB roundtrip that could be avoided for the current user (already in session).
+Observed latest local timing:
 
-**Root cause:** No caching of internal admin role within the request.
-
-### Finding 3 — Serial queries in some pages (MEDIUM)
-
-In `admin-desa.context` and `admin-desa.list-admin`, queries are already parallelized where
-possible. However, the layout runs `auth()` then `getAdminDesaContext()` sequentially — these
-could be parallelized with `Promise.all()` since they are independent.
-
-### Finding 4 — Overfetch in internal-admin documents (LOW)
-
-`adminDesaDocument.findMany` was selecting `aiMappingResult` (a potentially large JSON blob)
-for every row in the list. This field is only used in the PublishModal which is opened by user
-action (not rendered on initial page load). Removed from list select; still available via
-on-demand fetch if needed.
-
-### Finding 5 — Missing DB indexes for renewal queries (MEDIUM, needs verification)
-
-`internal-admin/renewals` queries `desaAdminMember` filtered by `status + renewalDueAt`:
-
-```prisma
-where: { status: "VERIFIED", renewalDueAt: { lte: horizon } }
+```text
+route=/desa public load durationMs≈320
 ```
 
-The existing index `[desaId, status]` does not cover `renewalDueAt`.  
-A compound index `[status, renewalDueAt]` would help for queries without `desaId` filter.
+Key difference from back office:
+
+- Public `/desa` reads broad public data with existing indexes on relation tables (`desaId`, `[desaId, tahun]`, etc.).
+- Back office `/profil/admin-desa/dokumen` starts with personalized membership lookup by `userId + status`,
+  but `DesaAdminMember` currently has only `@@unique([desaId, userId])` and `@@index([desaId, status])`.
+- Back office documents are filtered by `desaId` but ordered by `status ASC, createdAt DESC`; current
+  `AdminDesaDocument` indexes are single-column `desaId`, `status`, and `uploadedById`, so the DB may need
+  an additional sort or bitmap/index combination instead of scanning in final order.
 
 ---
 
-## 4. Changes Implemented
+## 4. Query Shapes Under Audit
 
-### Phase 1 — Instrumentation
-- Created `src/lib/perf.ts` with dev-only `perfLog`, `perfStart`, `perfTime`
-- Wired into all layouts, pages, and data helpers
+### 4.1 `getAdminDesaContext` / `desaAdminMember.findFirst`
 
-### Phase 2 — Loading boundaries
-Added `loading.tsx` for all tab sub-routes (existing skeletons already existed for the
-top-level `/profil/admin-desa` and `/internal-admin` layouts):
+Prisma shape:
 
-```
-src/app/profil/admin-desa/profil/loading.tsx      ✓ NEW
-src/app/profil/admin-desa/list-admin/loading.tsx  ✓ NEW
-src/app/profil/admin-desa/dokumen/loading.tsx     ✓ NEW
-src/app/profil/admin-desa/suara/loading.tsx       ✓ NEW
-src/app/profil/admin-desa/notifikasi/loading.tsx   ✓ NEW
-src/app/internal-admin/claims/loading.tsx          ✓ NEW
-src/app/internal-admin/documents/loading.tsx       ✓ NEW
-src/app/internal-admin/renewals/loading.tsx        ✓ NEW
-```
-
-All skeletons: quiet-luxury style, mobile-friendly, no dummy data, screen-reader labels.
-
-### Phase 3 — Request-level dedupe
-- `getAdminDesaContext()` wrapped with `React.cache()` — layout + page share one DB call
-- `isInternalAdmin()` wrapped with `React.cache()` — repeated role checks within a request are deduplicated
-
-### Phase 4 — Low-risk overfetch trim
-- Removed `aiMappingResult` from `adminDesaDocument.findMany` select in `/internal-admin/documents`
-- Made `aiMappingResult` optional in `DocRow` type (PublishModal handles `undefined` gracefully)
-
----
-
-## 5. DB Index Proposal (Phase 5)
-
-> **Do NOT migrate without owner approval.**
-
-### Proposal 1 — Renewal queries
-```
-Model:         DesaAdminMember
-Index:         [status, renewalDueAt]
-Query helped:   WHERE status = 'VERIFIED' AND renewalDueAt <= $horizon
-Risk:          LOW — index on existing columns, no data change
-Benefit:       Faster /internal-admin/renewals page load
-Migration now:  NO — needs review
+```ts
+await db.desaAdminMember.findFirst({
+  where: {
+    userId,
+    status: { in: ["LIMITED", "VERIFIED"] },
+  },
+  orderBy: { updatedAt: "desc" },
+  select: {
+    id: true,
+    desaId: true,
+    role: true,
+    status: true,
+    joinedAt: true,
+    invitedAt: true,
+    acceptedAt: true,
+    verifiedById: true,
+    renewalDueAt: true,
+    revokedAt: true,
+    revokedReason: true,
+    desa: { select: { id: true, nama: true, slug: true, kecamatan: true, kabupaten: true, provinsi: true, websiteUrl: true } },
+    user: { select: { id: true, nama: true, username: true, email: true, avatarUrl: true } },
+  },
+});
 ```
 
-### Proposal 2 — Notification lookup
-```
-Model:         AdminDesaNotification
-Index:         [userId, createdAt]
-Query helped:   WHERE userId = $id ORDER BY createdAt DESC
-Risk:          LOW — covers common access pattern
-Benefit:       Faster /profil/admin-desa/notifikasi
-Migration now:  NO — needs review
+Sanitized runtime shape log:
+
+```text
+[perf][back-office] route=admin-desa.context query=desaAdminMember.findFirst shape=where:userId,statusIn(LIMITED,VERIFIED);orderBy:updatedAtDesc;take:1;join:desa,user;select:memberContextFields
 ```
 
-### Proposal 3 — Document filter by status
+Expected SQL skeleton for EXPLAIN (values intentionally redacted):
+
+```sql
+EXPLAIN (ANALYZE, BUFFERS, VERBOSE)
+SELECT m.id, m."desaId", m.role, m.status, m."joinedAt", m."invitedAt", m."acceptedAt",
+       m."verifiedById", m."renewalDueAt", m."revokedAt", m."revokedReason",
+       d.id, d.nama, d.slug, d.kecamatan, d.kabupaten, d.provinsi, d."websiteUrl",
+       u.id, u.nama, u.username, u.email, u."avatarUrl"
+FROM desa_admin_members m
+JOIN desa d ON d.id = m."desaId"
+JOIN users u ON u.id = m."userId"
+WHERE m."userId" = '<redacted-user-id>'
+  AND m.status IN ('LIMITED', 'VERIFIED')
+ORDER BY m."updatedAt" DESC
+LIMIT 1;
 ```
-Model:         AdminDesaDocument
-Index:         [status, updatedAt]
-Query helped:   WHERE status = $filter ORDER BY updatedAt DESC
-Risk:          LOW
-Benefit:       Faster /internal-admin/documents filtered view
-Migration now:  NO — needs review
-```
 
----
+Index coverage today:
 
-## 6. Third-Party Library Assessment
-
-| Library | Use case | Recommendation |
+| Existing index | Helps this query? | Gap |
 |---|---|---|
-| `@vercel/otel` / OpenTelemetry | Route tracing, server timing | Consider after manual logging proves insufficient |
-| Prisma Accelerate | Connection pooling, edge caching | Do NOT add yet — cold-start bottleneck not confirmed |
-| TanStack Query | Client-side SWR, optimistic updates | Do NOT add — auth/cache design not mature for sensitive back office |
-| Prisma Optimize | Missing index detection | Recommended for pre-migration audit |
+| `@@unique([desaId, userId])` | No, leading column is `desaId`; query starts with `userId` | Cannot seek efficiently by `userId` alone |
+| `@@index([desaId, status])` | No, leading column is `desaId`; query starts with `userId` | Cannot cover `userId + status` |
+
+Likely plan risk: sequential scan or inefficient scan over `desa_admin_members`, followed by filter on
+`userId/status` and sort by `updatedAt DESC` before `LIMIT 1`.
+
+### 4.2 `/profil/admin-desa/dokumen` / `adminDesaDocument.findMany`
+
+Prisma shape:
+
+```ts
+await db.adminDesaDocument.findMany({
+  where: { desaId: ctx.desa.id },
+  orderBy: [{ status: "asc" }, { createdAt: "desc" }],
+  take: 100,
+  select: {
+    id: true,
+    title: true,
+    category: true,
+    fileName: true,
+    fileType: true,
+    fileSize: true,
+    status: true,
+    approvedAt: true,
+    publishedAt: true,
+    failedReason: true,
+    rejectedReason: true,
+    createdAt: true,
+    uploadedById: true,
+    uploadedBy: { select: { id: true, nama: true, username: true, email: true } },
+  },
+});
+```
+
+Sanitized runtime shape log:
+
+```text
+[perf][back-office] route=admin-desa.dokumen query=adminDesaDocument.findMany shape=where:desaId;orderBy:statusAsc,createdAtDesc;take:100;join:uploadedBy;select:listFields
+```
+
+Expected SQL skeleton for EXPLAIN (values intentionally redacted):
+
+```sql
+EXPLAIN (ANALYZE, BUFFERS, VERBOSE)
+SELECT doc.id, doc.title, doc.category, doc."fileName", doc."fileType", doc."fileSize",
+       doc.status, doc."approvedAt", doc."publishedAt", doc."failedReason", doc."rejectedReason",
+       doc."createdAt", doc."uploadedById",
+       uploader.id, uploader.nama, uploader.username, uploader.email
+FROM admin_desa_documents doc
+LEFT JOIN users uploader ON uploader.id = doc."uploadedById"
+WHERE doc."desaId" = '<redacted-desa-id>'
+ORDER BY doc.status ASC, doc."createdAt" DESC
+LIMIT 100;
+```
+
+Index coverage today:
+
+| Existing index | Helps this query? | Gap |
+|---|---|---|
+| `@@index([desaId])` | Partially filters rows for one desa | Does not satisfy `ORDER BY status, createdAt` |
+| `@@index([status])` | Not useful when filtering by `desaId` first | May require combining/sorting |
+| `@@index([uploadedById])` | Helps relation lookup from document to user only in other access patterns | Not relevant for filter/order |
+
+Likely plan risk: index scan by `desaId` followed by explicit sort on `status ASC, createdAt DESC`, or a
+bitmap scan plus sort. This can become expensive as one desa accumulates documents.
 
 ---
 
-## 7. Prioritized Recommendations
+## 5. EXPLAIN ANALYZE Status
 
-### P0 — Safe, can ship now
-1. ✅ React `cache()` on `getAdminDesaContext` and `isInternalAdmin` — reduces duplicate DB calls
-2. ✅ Remove `aiMappingResult` from document list — smaller response payload
-3. ✅ Loading skeletons — no more blank/freeze screens
-4. ✅ Perf instrumentation — owners can now measure real durations
+### 5.1 Agent environment result
 
-### P1 — Needs owner review before merge
-1. Parallelize `auth()` + `getAdminDesaContext()` with `Promise.all()` in admin-desa layout
-2. DB index proposals (Phase 5) — need migration review
-3. Serial auth optimization for internal-admin (cache user role after first look-up)
-
-### P2 — Needs migration / infra / third party
-1. Prisma Accelerate — only if cold-start latency > 500ms proven
-2. TanStack Query — only after auth + cache strategy is designed
-3. OpenTelemetry — only if manual perf logging proves insufficient for ongoing monitoring
-
----
-
-## 8. Acceptance Checklist
-
-- [x] Audit report written
-- [x] Instrumentation helper created (`src/lib/perf.ts`)
-- [x] Perf logging wired into all back office layouts + pages + data helpers
-- [x] `React.cache()` applied to `getAdminDesaContext` and `isInternalAdmin`
-- [x] Loading skeletons added for all tab sub-routes
-- [x] `aiMappingResult` removed from internal-admin documents list query
-- [x] `DocRow.aiMappingResult` made optional in component type
-- [x] Business logic unchanged (no approval/reject/role changes)
-- [x] No DB migration added
-- [ ] Duration measurements from local/staging run (pending — run `npm run dev` and test)
-- [ ] `npm run lint` — pending
-- [ ] `npx tsc --noEmit` — pending
-- [ ] `npm run build` — pending
-
----
-
-## 9. How to Measure
+Attempted in the agent environment on 2026-05-05:
 
 ```bash
-# Enable verbose perf logging (also active in dev mode by default)
-PERF_DEBUG_BACK_OFFICE=true npm run dev
-
-# Visit each route and watch console for:
-# [perf][back-office] route=admin-desa.layout step=auth() durationMs=47
-# [perf][back-office] route=admin-desa.context step=desaAdminMember.findFirst durationMs=12
+node - <<'NODE'
+if (!process.env.DATABASE_URL && !process.env.DIRECT_URL) {
+  console.error('EXPLAIN_ANALYZE_SKIPPED: DATABASE_URL/DIRECT_URL unset in agent environment')
+  process.exit(2)
+}
+NODE
 ```
 
-Thresholds to investigate:
-- `auth()` > 200ms → NextAuth or session store issue
-- `findFirst` / `findMany` > 200ms → missing index or cold connection
-- Total wall time > 2000ms → sequential query waterfall
+Result:
+
+```text
+EXPLAIN_ANALYZE_SKIPPED: DATABASE_URL/DIRECT_URL unset in agent environment
+```
+
+So this patch does **not** claim a captured Supabase execution plan. The query-plan run is blocked in the
+agent environment because no local/Supabase database URL is available. The SQL skeletons above are ready to
+run locally with redacted parameters. The migration decision should wait for owner-approved EXPLAIN output.
+
+### 5.2 What to capture before approving migration
+
+For each query, capture:
+
+- Scan type: `Seq Scan`, `Index Scan`, `Bitmap Index Scan`, `Bitmap Heap Scan`
+- Sort node: whether `Sort` appears, sort method, memory/disk usage
+- Rows removed by filter
+- Actual time and row counts per node
+- Buffer reads/hits
+- Whether joins to `desa` and `users` are cheap primary-key lookups
+
+A migration is only justified after the plan confirms either:
+
+1. `desa_admin_members` is not using an index compatible with `userId + status`, or
+2. `admin_desa_documents` must sort filtered rows because no index matches `desaId + status + createdAt`.
 
 ---
 
-*Report generated by Sprint 04-008F execution. Instrumentation is dev-only and has no
-performance impact in production.*
+## 6. DB Index Proposals — Evidence Before Migration
+
+> **Do NOT create a migration until this report is approved.**
+
+### Proposal A — Admin Desa context lookup
+
+```prisma
+model DesaAdminMember {
+  @@index([userId, status])
+}
+```
+
+Query helped:
+
+```text
+WHERE userId = ? AND status IN ('LIMITED', 'VERIFIED')
+ORDER BY updatedAt DESC
+LIMIT 1
+```
+
+Risk: LOW. New read index on existing columns, no data change.
+
+Expected benefit: turns the slow context lookup into a selective index scan by `userId + status`.
+
+Open question: because the query also orders by `updatedAt DESC`, EXPLAIN may show that
+`[userId, status, updatedAt]` would be even better. The requested safe proposal is `[userId, status]`;
+final migration should be chosen after real plan data.
+
+### Proposal B — Document list by desa + created date
+
+```prisma
+model AdminDesaDocument {
+  @@index([desaId, createdAt])
+}
+```
+
+Query helped:
+
+```text
+WHERE desaId = ?
+ORDER BY createdAt DESC
+```
+
+Risk: LOW. Useful for any documents list that only needs newest documents per desa.
+
+Expected benefit: helps newest-first variants, but does not fully match the current tab order
+`status ASC, createdAt DESC`.
+
+### Proposal C — Document list by desa + status + created date
+
+```prisma
+model AdminDesaDocument {
+  @@index([desaId, status, createdAt])
+}
+```
+
+Query helped:
+
+```text
+WHERE desaId = ?
+ORDER BY status ASC, createdAt DESC
+LIMIT 100
+```
+
+Risk: LOW to MEDIUM. Read index on existing columns, but more write overhead than Proposal B.
+
+Expected benefit: best match for the current `/profil/admin-desa/dokumen` query shape because it filters
+by `desaId` and orders by `status + createdAt`. If Postgres uses this index for ordered retrieval, it can
+avoid a separate sort for the first 100 rows.
+
+Open question: Prisma/Postgres index sort direction should be reviewed before migration. If the planner
+cannot use an ascending `createdAt` index efficiently for `createdAt DESC`, migration may need explicit
+sort direction support in Prisma schema or raw SQL.
+
+---
+
+## 7. Why `/desa` Can Load Around 320ms
+
+Public `/desa` uses `getDesaListResult()` → `fetchDesaRecords()` and reads a public data graph:
+
+- `desa.findMany` ordered by `provinsi`, `kabupaten`, `nama`
+- relation reads for `dataSources`
+- `anggaranSummaries` with `take: 1`, ordered by `tahun DESC`
+- `apbdesItems`
+- `dokumenPublik`
+
+Relevant existing indexes:
+
+- `anggaran_desa_summaries`: `@@unique([desaId, tahun])`
+- `apbdes_items`: `@@index([desaId, tahun])`
+- `dokumen_publik`: `@@index([desaId, tahun])`
+- `data_sources`: `@@index([desaId])`
+
+Back office differs because the first blocking query is personalized and starts from `userId`, while the
+existing `DesaAdminMember` compound indexes start from `desaId`. Then the documents page sorts by a compound
+order that no existing `AdminDesaDocument` compound index satisfies.
+
+---
+
+## 8. Prioritized Recommendations
+
+### P0 — safest next step after EXPLAIN confirms plan
+
+1. Add an index for `DesaAdminMember` context lookup. Requested proposal: `[userId, status]`.
+2. Add an index for `AdminDesaDocument` matching the active documents tab query. Requested proposal:
+   `[desaId, status, createdAt]`.
+3. Keep query-shape logging enabled in development/staging until post-index measurements show main data
+   renders under 1 second.
+
+### P1 — small refactor only after P0 evidence
+
+1. Consider trimming `getAdminDesaContext` relation select if the layout does not need all user/desa fields.
+2. Consider splitting document list relation data so uploader fields are fetched only where displayed.
+3. Consider request-level streaming boundaries so the shell/shimmer appears under 1 second even when DB is slow.
+
+### P2 — infra / third party only if query/index fixes are insufficient
+
+1. Review Supabase connection pooling and region if indexed queries still exceed 500–800ms.
+2. Consider Prisma Accelerate only after query plans are healthy and network/connection latency remains proven.
+3. Consider OpenTelemetry (`@vercel/otel`) after manual perf logs become insufficient for ongoing diagnosis.
+
+---
+
+## 9. Acceptance Checklist
+
+- [x] Latest local measurement evidence added
+- [x] Query-shape logging added for `getAdminDesaContext` / `desaAdminMember.findFirst`
+- [x] Query-shape logging added for `/profil/admin-desa/dokumen` / `adminDesaDocument.findMany`
+- [x] Query shapes avoid logging `userId`, `desaId`, or `email` values
+- [x] No UI refactor
+- [x] No business logic change
+- [x] No migration added
+- [x] Index proposals documented without migration
+- [x] Public `/desa` query path compared with back-office path
+- [ ] Real Supabase `EXPLAIN ANALYZE` captured — blocked in agent env because `DATABASE_URL`/`DIRECT_URL` is unset
+- [x] `npm run lint` — passed 2026-05-05
+- [x] `npx tsc --noEmit` — passed 2026-05-05
+- [ ] `npm run build` — attempted 2026-05-05; blocked by Google Fonts fetch failure for `Inter` in this environment

--- a/src/app/profil/admin-desa/dokumen/page.tsx
+++ b/src/app/profil/admin-desa/dokumen/page.tsx
@@ -13,7 +13,7 @@ import {
   getAllowedMimeTypes,
 } from "@/lib/storage/upload-validation";
 import { getStorageConfigurationStatus } from "@/lib/storage/supabase-storage";
-import { perfLog, perfStart } from "@/lib/perf";
+import { perfLog, perfQueryShape, perfStart } from "@/lib/perf";
 
 export const dynamic = "force-dynamic";
 
@@ -25,6 +25,11 @@ export default async function AdminDesaDokumenPage() {
   const ctx = await getAdminDesaContext(session.user.id);
   if (!ctx) redirect("/profil/klaim-admin-desa?error=admin_desa_only");
 
+  perfQueryShape(
+    "admin-desa.dokumen",
+    "adminDesaDocument.findMany",
+    "where:desaId;orderBy:statusAsc,createdAtDesc;take:100;join:uploadedBy;select:listFields",
+  );
   const tDocs = perfStart();
   const docs = db
     ? await db.adminDesaDocument.findMany({

--- a/src/lib/data/admin-desa-context.ts
+++ b/src/lib/data/admin-desa-context.ts
@@ -1,7 +1,7 @@
 import { cache } from "react";
 import { db } from "@/lib/db";
 import { getRenewalState, daysUntilRenewal, type RenewalState } from "@/lib/admin-claim/renewal";
-import { perfLog, perfStart } from "@/lib/perf";
+import { perfLog, perfQueryShape, perfStart } from "@/lib/perf";
 
 export interface AdminDesaContext {
   member: {
@@ -54,6 +54,11 @@ export const getAdminDesaContext = cache(async function getAdminDesaContext(
 ): Promise<AdminDesaContext | null> {
   if (!db) return null;
 
+  perfQueryShape(
+    "admin-desa.context",
+    "desaAdminMember.findFirst",
+    "where:userId,statusIn(LIMITED,VERIFIED);orderBy:updatedAtDesc;take:1;join:desa,user;select:memberContextFields",
+  );
   const t = perfStart();
   const member = await db.desaAdminMember.findFirst({
     where: {

--- a/src/lib/perf.ts
+++ b/src/lib/perf.ts
@@ -7,13 +7,16 @@
  *  - `NODE_ENV !== "production"` (always on in dev/test)
  *  - `process.env.PERF_DEBUG_BACK_OFFICE === "true"` (opt-in for staging)
  *
- * Output format (single line, easy to grep):
+ * Output formats (single line, easy to grep):
  *   [perf][back-office] route=<route> step=<step> durationMs=<number>
+ *   [perf][back-office] route=<route> query=<model.method> shape=<static-shape>
  *
  * Privacy guardrails:
  *  - Caller is responsible for NOT passing emails, user ids, tokens, sessions,
  *    or document content into `route` / `step`. Helper does not echo any extra
  *    metadata to keep this surface boring on purpose.
+ *  - Query shape logging must describe predicates/order/selects without values
+ *    (e.g. `where:userId,statusIn`, never the actual userId/desaId/email).
  *  - No persistence. Goes only to `console.info`.
  *
  * Usage:
@@ -40,6 +43,12 @@ export function perfLog(route: string, step: string, startedAt: number): void {
   const durationMs = Date.now() - startedAt;
   // Single-line, machine-grep friendly. No PII.
   console.info(`[perf][back-office] route=${route} step=${step} durationMs=${durationMs}`);
+}
+
+export function perfQueryShape(route: string, query: string, shape: string): void {
+  if (!perfEnabled()) return;
+  // Static query metadata only. Do not pass userId/desaId/email or document content here.
+  console.info(`[perf][back-office] route=${route} query=${query} shape=${shape}`);
 }
 
 export async function perfTime<T>(


### PR DESCRIPTION
### Motivation
- Narrow down root cause of slow back-office pages after initial instrumentation showed auth is not the bottleneck and DB queries dominate `/profil/admin-desa/dokumen` latency. 
- Capture query shapes (without PII) so EXPLAIN runs can be prepared and index proposals validated before any migration. 
- Provide evidence + safe index proposals for owner review to meet the target: main back-office data render <1s. 

### Description
- Added query-shape logging helper `perfQueryShape` and documented guardrails in `src/lib/perf.ts` to emit sanitized static query metadata (no `userId`/`desaId`/`email`).
- Instrumented `getAdminDesaContext` (`desaAdminMember.findFirst`) and `/profil/admin-desa/dokumen` (`adminDesaDocument.findMany`) to log sanitized query shapes and retained duration logging (`perfLog`).
- Updated the audit doc `docs/bmad/reports/back-office-performance-audit.md` with latest local measurements (`auth()` 36ms, `desaAdminMember.findFirst` 1648ms, `adminDesaDocument.findMany` 1298ms), EXPLAIN SQL skeletons, index coverage analysis, and three index proposals: `DesaAdminMember @@index([userId, status])`, `AdminDesaDocument @@index([desaId, createdAt])`, and `AdminDesaDocument @@index([desaId, status, createdAt])` (proposals only; no migration). 
- Kept code-level mitigations (React `cache()` already applied earlier) and avoided UI, business-logic, or migration changes per constraints. 

### Testing
- Ran `npm run lint` and it passed in this environment. 
- Ran `npx tsc --noEmit` and it passed in this environment. 
- Attempted `npm run build` but the build failed due to an environment/network issue fetching Google Font `Inter` from `fonts.googleapis.com` (blocked in this agent environment). 
- Attempted to run `EXPLAIN ANALYZE` but it was skipped because `DATABASE_URL`/`DIRECT_URL` are unset in the agent environment, so real plan capture is pending local/Supabase runs by the owner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94f14d314832ab8b0b0610b1fcd9f)